### PR TITLE
Change type of seed from string to int

### DIFF
--- a/__tests__/Tinycolor_tests.re
+++ b/__tests__/Tinycolor_tests.re
@@ -486,7 +486,13 @@ describe("color utils", () => {
 
   test("random() with options", () => {
     let a =
-      TinyColor.random(~hue=`green, ~luminosity=`bright, ~alpha=0.85, ());
+      TinyColor.random(
+        ~hue=`green,
+        ~seed=719,
+        ~luminosity=`bright,
+        ~alpha=0.85,
+        (),
+      );
 
     expect(TinyColor.getAlpha(a)) |> toBe(0.85);
   });

--- a/src/TinyColor.re
+++ b/src/TinyColor.re
@@ -363,7 +363,7 @@ external randomConfig:
           ]
             =?,
     ~luminosity: [@bs.string] [ | `bright | `light | `dark]=?,
-    ~seed: string=?,
+    ~seed: int=?,
     ~alpha: float=?,
     ~count: int=?,
     unit
@@ -386,7 +386,7 @@ let random =
            ],
          )=?,
       ~luminosity: option([ | `bright | `light | `dark])=?,
-      ~seed: option(string)=?,
+      ~seed: option(int)=?,
       ~alpha: option(float)=?,
       (),
     ) =>
@@ -408,7 +408,7 @@ let randomMultiple =
            ],
          )=?,
       ~luminosity: option([ | `bright | `light | `dark])=?,
-      ~seed: option(string)=?,
+      ~seed: option(int)=?,
       ~alpha: option(float)=?,
       ~count: int,
       (),


### PR DESCRIPTION
Related to #13, this replaced the type signature of seed with int to make it align with the type signature of the TinyColor seed.